### PR TITLE
Use holiday names from code du travail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changements
 
-## 0.7.0 - 2020-05-14
+## 0.7.0 - 2020-05-15
 
 - ⚠️ Utilisation des noms des jours fériés en vigueur dans le code du travail
 - ⚠️ Changement du nom des méthodes pour chaque jour férié pour correspondre au code du travail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# Changements
+
+## 0.7.0 - 2020-05-14
+
+- ⚠️ Utilisation des noms des jours fériés en vigueur dans le code du travail
+- ⚠️ Changement du nom des méthodes pour chaque jour férié pour correspondre au code du travail

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ print(JoursFeries.ZONES)
 ```
 
 ### Noms des jours fériés
-Les noms des jours fériés sont fixés d'après le code du travail.
+Les noms des jours fériés sont fixés d'[après le code du travail](#sources).
 
 Pour les zones `Métropole` (par défaut), `Nouvelle-Calédonie`, `Polynésie Française`, `Saint-Pierre-et-Miquelon` et `Wallis-et-Futuna`, les jours fériés sont orthographiés de la façon suivante :
 - `1er janvier`
@@ -134,7 +134,7 @@ Certaines méthodes acceptent une `zone` en paramètre car ce jour férié est s
 Si vous souhaitez simplement un export, consultez le jeu de données ["Jours fériés en France"](https://www.data.gouv.fr/fr/datasets/jours-feries-en-france/) sur data.gouv.fr.
 
 ## Sources
-La liste des jours fériés est définie dans le code du travail.
+La liste des jours fériés est définie [dans le code du travail](#sources).
 
 Certaines commémorations locales ou professionnelles sont également des jours fériés, parmi lesquelles :
 - Saint-Éloi (reconnu jour férié par certaines conventions collectives dans la métallurgie) ;

--- a/README.md
+++ b/README.md
@@ -22,17 +22,17 @@ from jours_feries_france import JoursFeries
 res = JoursFeries.for_year(2018)
 # res est un dictionnaire
 # {
-#     "Jour de l'an": date(2018, 1, 1),
-#     "Lundi de Pâques": date(2018, 4, 2),
-#     "Fête du Travail": date(2018, 5, 1),
-#     "Victoire des alliés": date(2018, 5, 8),
-#     "Ascension": date(2018, 5, 10),
-#     "Lundi de Pentecôte": date(2018, 5, 21),
-#     "Fête Nationale": date(2018, 7, 14),
-#     "Assomption": date(2018, 8, 15),
-#     "Toussaint": date(2018, 11, 1),
-#     "Armistice": date(2018, 11, 11),
-#     "Noël": date(2018, 12, 25),
+#     '1er janvier': datetime.date(2018, 1, 1),
+#     'Lundi de Pâques': datetime.date(2018, 4, 2),
+#     '1er mai': datetime.date(2018, 5, 1),
+#     '8 mai': datetime.date(2018, 5, 8),
+#     'Ascension': datetime.date(2018, 5, 10),
+#     'Lundi de Pentecôte': datetime.date(2018, 5, 21),
+#     '14 juillet': datetime.date(2018, 7, 14),
+#     'Assomption': datetime.date(2018, 8, 15),
+#     'Toussaint': datetime.date(2018, 11, 1),
+#     '11 novembre': datetime.date(2018, 11, 11),
+#     'Jour de Noël': datetime.date(2018, 12, 25)
 # }
 
 # Vous pouvez aussi obtenir certains jours fériés en tant que datetime.date
@@ -65,6 +65,42 @@ Les zones suivantes sont disponibles :
 - `Saint-Martin`
 - `Saint-Pierre-et-Miquelon`
 - `Wallis-et-Futuna`
+
+Ces zones sont disponibles dans une constante :
+```python
+from jours_feries_france import JoursFeries
+
+print(JoursFeries.ZONES)
+# [
+#     'Métropole', 'Alsace-Moselle', 'Guadeloupe',
+#     'Guyane', 'Martinique', 'Mayotte', 'Nouvelle-Calédonie',
+#     'La Réunion', 'Polynésie Française', 'Saint-Barthélémy',
+#     'Saint-Martin', 'Wallis-et-Futuna', 'Saint-Pierre-et-Miquelon'
+# ]
+```
+
+### Noms des jours fériés
+Les noms des jours fériés sont fixés d'après le code du travail.
+
+Pour les zones `Métropole` (par défaut), `Nouvelle-Calédonie`, `Polynésie Française`, `Saint-Pierre-et-Miquelon` et `Wallis-et-Futuna`, les jours fériés sont orthographiés de la façon suivante :
+- `1er janvier`
+- `Lundi de Pâques`
+- `1er mai`
+- `8 mai`
+- `Ascension`
+- `Lundi de Pentecôte`
+- `14 juillet`
+- `Assomption`
+- `Toussaint`
+- `11 novembre`
+- `Jour de Noël`
+
+Pour la zone `Alsace-Moselle`, il existe 2 jours fériés supplémentaires, orthographiés de la façon suivante :
+- `2ème jour de Noël`
+- `Vendredi saint`
+
+Pour les zones `Guadeloupe`, `Guyane`, `La Réunion`, `Martinique`, `Mayotte`, `Saint-Barthélémy` et `Saint-Martin`, il existe un jour férié supplémentaire, orthographié de la façon suivante :
+- `Abolition de l'esclavage`
 
 ## Données
 Si vous souhaitez simplement un export, consultez le jeu de données ["Jours fériés en France"](https://www.data.gouv.fr/fr/datasets/jours-feries-en-france/) sur data.gouv.fr.

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ res = JoursFeries.for_year(2018)
 # }
 
 # Vous pouvez aussi obtenir certains jours fériés en tant que datetime.date
-print (JoursFeries.lundiDePaques(2018))
+print (JoursFeries.lundi_paques(2018))
 print (JoursFeries.ascension(2018))
-print (JoursFeries.lundiDePentecote(2018))
+print (JoursFeries.lundi_pentecote(2018))
 
 # Obtenir les jours fériés pour une zone spécifique
 res = JoursFeries.for_year(2018, zone="Alsace-Moselle")
@@ -101,6 +101,34 @@ Pour la zone `Alsace-Moselle`, il existe 2 jours fériés supplémentaires, orth
 
 Pour les zones `Guadeloupe`, `Guyane`, `La Réunion`, `Martinique`, `Mayotte`, `Saint-Barthélémy` et `Saint-Martin`, il existe un jour férié supplémentaire, orthographié de la façon suivante :
 - `Abolition de l'esclavage`
+
+### Noms des méthodes Python
+
+Vous pouvez calculer chaque jour férié individuellement à l'aide d'une méthode spécifique.
+
+```python
+from jours_feries_france import JoursFeries
+
+year = 2020
+zone = 'Métropole'
+
+print("1er janvier", JoursFeries.premier_janvier(year))
+print("1er mai", JoursFeries.premier_mai(year))
+print("8 mai", JoursFeries.huit_mai(year))
+print("14 juillet", JoursFeries.quatorze_juillet(year))
+print("Assomption", JoursFeries.assomption(year))
+print("Toussaint", JoursFeries.toussaint(year))
+print("11 novembre", JoursFeries.onze_novembre(year))
+print("Jour de Noël", JoursFeries.jour_noel(year))
+print("Lundi de Pâques", JoursFeries.lundi_paques(year))
+print("Ascension", JoursFeries.ascension(year))
+print("Lundi de Pentecôte", JoursFeries.lundi_pentecote(year))
+print("Vendredi saint", JoursFeries.vendredi_saint(year, zone))
+print("2ème jour de Noël", JoursFeries.deuxieme_jour_noel(year, zone))
+print("Abolition de l'esclavage", JoursFeries.abolition_esclavage(year, zone))
+```
+
+Certaines méthodes acceptent une `zone` en paramètre car ce jour férié est spécifique à certaines zones. Si ce jour férié n'est pas férié pour la zone passée en argument, vous aurez la valeur `None` en retour au lieu d'une date.
 
 ## Données
 Si vous souhaitez simplement un export, consultez le jeu de données ["Jours fériés en France"](https://www.data.gouv.fr/fr/datasets/jours-feries-en-france/) sur data.gouv.fr.

--- a/jours_feries_france/__init__.py
+++ b/jours_feries_france/__init__.py
@@ -56,19 +56,19 @@ class JoursFeries(object):
         JoursFeries.check_zone(zone)
 
         bank_holidays = {
-            "Jour de l'an": JoursFeries.jourDeLAn(year),
-            "Fête du Travail": JoursFeries.feteDuTravail(year),
-            "Victoire des alliés": JoursFeries.victoireDesAllies(year),
-            "Fête Nationale": JoursFeries.feteNationale(year),
+            "1er janvier": JoursFeries.jourDeLAn(year),
+            "1er mai": JoursFeries.feteDuTravail(year),
+            "8 mai": JoursFeries.victoireDesAllies(year),
+            "14 juillet": JoursFeries.feteNationale(year),
             "Assomption": JoursFeries.assomption(year),
             "Toussaint": JoursFeries.toussaint(year),
-            "Armistice": JoursFeries.armistice(year),
-            "Noël": JoursFeries.noel(year),
+            "11 novembre": JoursFeries.armistice(year),
+            "Jour de Noël": JoursFeries.noel(year),
             "Lundi de Pâques": JoursFeries.lundiDePaques(year),
             "Ascension": JoursFeries.ascension(year),
             "Lundi de Pentecôte": JoursFeries.lundiDePentecote(year),
-            "Vendredi Saint": JoursFeries.vendrediSaint(year, zone),
-            "Saint Étienne": JoursFeries.saintEtienne(year, zone),
+            "Vendredi saint": JoursFeries.vendrediSaint(year, zone),
+            "2ème jour de Noël": JoursFeries.saintEtienne(year, zone),
             "Abolition de l'esclavage": JoursFeries.abolitionDeLesclavage(year, zone),
         }
 

--- a/jours_feries_france/__init__.py
+++ b/jours_feries_france/__init__.py
@@ -56,20 +56,20 @@ class JoursFeries(object):
         JoursFeries.check_zone(zone)
 
         bank_holidays = {
-            "1er janvier": JoursFeries.jourDeLAn(year),
-            "1er mai": JoursFeries.feteDuTravail(year),
-            "8 mai": JoursFeries.victoireDesAllies(year),
-            "14 juillet": JoursFeries.feteNationale(year),
+            "1er janvier": JoursFeries.premier_janvier(year),
+            "1er mai": JoursFeries.premier_mai(year),
+            "8 mai": JoursFeries.huit_mai(year),
+            "14 juillet": JoursFeries.quatorze_juillet(year),
             "Assomption": JoursFeries.assomption(year),
             "Toussaint": JoursFeries.toussaint(year),
-            "11 novembre": JoursFeries.armistice(year),
-            "Jour de Noël": JoursFeries.noel(year),
-            "Lundi de Pâques": JoursFeries.lundiDePaques(year),
+            "11 novembre": JoursFeries.onze_novembre(year),
+            "Jour de Noël": JoursFeries.jour_noel(year),
+            "Lundi de Pâques": JoursFeries.lundi_paques(year),
             "Ascension": JoursFeries.ascension(year),
-            "Lundi de Pentecôte": JoursFeries.lundiDePentecote(year),
-            "Vendredi saint": JoursFeries.vendrediSaint(year, zone),
-            "2ème jour de Noël": JoursFeries.saintEtienne(year, zone),
-            "Abolition de l'esclavage": JoursFeries.abolitionDeLesclavage(year, zone),
+            "Lundi de Pentecôte": JoursFeries.lundi_pentecote(year),
+            "Vendredi saint": JoursFeries.vendredi_saint(year, zone),
+            "2ème jour de Noël": JoursFeries.deuxieme_jour_noel(year, zone),
+            "Abolition de l'esclavage": JoursFeries.abolition_esclavage(year, zone),
         }
 
         bank_holidays = {k: v for k, v in bank_holidays.items() if v}
@@ -93,13 +93,13 @@ class JoursFeries(object):
         return date(year, month, day)
 
     @staticmethod
-    def lundiDePaques(year):
+    def lundi_paques(year):
         if year >= 1886:
             return JoursFeries.paques(year) + timedelta(days=1)
         return None
 
     @staticmethod
-    def vendrediSaint(year, zone):
+    def vendredi_saint(year, zone):
         if zone == JoursFeries.check_zone("Alsace-Moselle"):
             return JoursFeries.paques(year) - timedelta(days=2)
         return None
@@ -111,31 +111,31 @@ class JoursFeries(object):
         return None
 
     @staticmethod
-    def lundiDePentecote(year):
+    def lundi_pentecote(year):
         if year >= 1886:
             return JoursFeries.paques(year) + timedelta(days=50)
         return None
 
     @staticmethod
-    def jourDeLAn(year):
+    def premier_janvier(year):
         if year > 1810:
             return date(year, 1, 1)
         return None
 
     @staticmethod
-    def feteDuTravail(year):
+    def premier_mai(year):
         if year > 1919:
             return date(year, 5, 1)
         return None
 
     @staticmethod
-    def victoireDesAllies(year):
+    def huit_mai(year):
         if (1953 <= year <= 1959) or year > 1981:
             return date(year, 5, 8)
         return None
 
     @staticmethod
-    def feteNationale(year):
+    def quatorze_juillet(year):
         if year >= 1880:
             return date(year, 7, 14)
         return None
@@ -153,25 +153,25 @@ class JoursFeries(object):
         return None
 
     @staticmethod
-    def armistice(year):
+    def onze_novembre(year):
         if year >= 1918:
             return date(year, 11, 11)
         return None
 
     @staticmethod
-    def noel(year):
+    def jour_noel(year):
         if year >= 1802:
             return date(year, 12, 25)
         return None
 
     @staticmethod
-    def saintEtienne(year, zone):
+    def deuxieme_jour_noel(year, zone):
         if zone == JoursFeries.check_zone("Alsace-Moselle"):
             return date(year, 12, 26)
         return None
 
     @staticmethod
-    def abolitionDeLesclavage(year, zone):
+    def abolition_esclavage(year, zone):
         if zone == JoursFeries.check_zone("Mayotte"):
             return date(year, 4, 27)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ setup(
     name="jours_feries_france",
     license="MIT",
     packages=["jours_feries_france"],
-    version="0.6.0",
+    version="0.7.0",
     description="Jours fériés en France, en métropole et en outre-mer.",
     author="Etalab",
     author_email="info@data.gouv.fr",

--- a/tests/test.py
+++ b/tests/test.py
@@ -28,17 +28,17 @@ class TestDatasetParser(unittest.TestCase):
 
     def test_next_bank_holiday(self):
         self.assertEquals(
-            ("Armistice", date(2018, 11, 11)),
+            ("11 novembre", date(2018, 11, 11)),
             JoursFeries.next_bank_holiday(date(2018, 11, 10)),
         )
 
         self.assertEquals(
-            ("Armistice", date(2018, 11, 11)),
+            ("11 novembre", date(2018, 11, 11)),
             JoursFeries.next_bank_holiday(date(2018, 11, 11), zone="Métropole"),
         )
 
         self.assertEquals(
-            ("Noël", date(2018, 12, 25)),
+            ("Jour de Noël", date(2018, 12, 25)),
             JoursFeries.next_bank_holiday(date(2018, 12, 11), zone="Métropole"),
         )
 
@@ -46,34 +46,34 @@ class TestDatasetParser(unittest.TestCase):
         self.assertDictEqual(
             JoursFeries.for_year(2018),
             {
-                "Jour de l'an": date(2018, 1, 1),
+                "1er janvier": date(2018, 1, 1),
                 "Lundi de Pâques": date(2018, 4, 2),
-                "Fête du Travail": date(2018, 5, 1),
-                "Victoire des alliés": date(2018, 5, 8),
+                "1er mai": date(2018, 5, 1),
+                "8 mai": date(2018, 5, 8),
                 "Ascension": date(2018, 5, 10),
                 "Lundi de Pentecôte": date(2018, 5, 21),
-                "Fête Nationale": date(2018, 7, 14),
+                "14 juillet": date(2018, 7, 14),
                 "Assomption": date(2018, 8, 15),
                 "Toussaint": date(2018, 11, 1),
-                "Armistice": date(2018, 11, 11),
-                "Noël": date(2018, 12, 25),
+                "11 novembre": date(2018, 11, 11),
+                "Jour de Noël": date(2018, 12, 25),
             },
         )
 
         self.assertDictEqual(
             JoursFeries.for_year(2020),
             {
-                "Armistice": date(2020, 11, 11),
+                "11 novembre": date(2020, 11, 11),
                 "Ascension": date(2020, 5, 21),
                 "Assomption": date(2020, 8, 15),
-                "Fête Nationale": date(2020, 7, 14),
-                "Fête du Travail": date(2020, 5, 1),
-                "Jour de l'an": date(2020, 1, 1),
+                "14 juillet": date(2020, 7, 14),
+                "1er mai": date(2020, 5, 1),
+                "1er janvier": date(2020, 1, 1),
                 "Lundi de Pâques": date(2020, 4, 13),
-                "Noël": date(2020, 12, 25),
+                "Jour de Noël": date(2020, 12, 25),
                 "Lundi de Pentecôte": date(2020, 6, 1),
                 "Toussaint": date(2020, 11, 1),
-                "Victoire des alliés": date(2020, 5, 8),
+                "8 mai": date(2020, 5, 8),
             },
         )
 
@@ -81,38 +81,38 @@ class TestDatasetParser(unittest.TestCase):
         self.assertDictEqual(
             JoursFeries.for_year(2018, zone="Alsace-Moselle"),
             {
-                "Armistice": date(2018, 11, 11),
+                "11 novembre": date(2018, 11, 11),
                 "Ascension": date(2018, 5, 10),
                 "Assomption": date(2018, 8, 15),
-                "Fête Nationale": date(2018, 7, 14),
-                "Fête du Travail": date(2018, 5, 1),
-                "Jour de l'an": date(2018, 1, 1),
+                "14 juillet": date(2018, 7, 14),
+                "1er mai": date(2018, 5, 1),
+                "1er janvier": date(2018, 1, 1),
                 "Lundi de Pâques": date(2018, 4, 2),
-                "Noël": date(2018, 12, 25),
+                "Jour de Noël": date(2018, 12, 25),
                 "Lundi de Pentecôte": date(2018, 5, 21),
                 "Toussaint": date(2018, 11, 1),
-                "Victoire des alliés": date(2018, 5, 8),
-                "Vendredi Saint": date(2018, 3, 30),
-                "Saint Étienne": date(2018, 12, 26),
+                "8 mai": date(2018, 5, 8),
+                "Vendredi saint": date(2018, 3, 30),
+                "2ème jour de Noël": date(2018, 12, 26),
             },
         )
 
         self.assertDictEqual(
             JoursFeries.for_year(2020, zone="Alsace-Moselle"),
             {
-                "Armistice": date(2020, 11, 11),
+                "11 novembre": date(2020, 11, 11),
                 "Ascension": date(2020, 5, 21),
                 "Assomption": date(2020, 8, 15),
-                "Fête Nationale": date(2020, 7, 14),
-                "Fête du Travail": date(2020, 5, 1),
-                "Jour de l'an": date(2020, 1, 1),
+                "14 juillet": date(2020, 7, 14),
+                "1er mai": date(2020, 5, 1),
+                "1er janvier": date(2020, 1, 1),
                 "Lundi de Pâques": date(2020, 4, 13),
-                "Noël": date(2020, 12, 25),
+                "Jour de Noël": date(2020, 12, 25),
                 "Lundi de Pentecôte": date(2020, 6, 1),
                 "Toussaint": date(2020, 11, 1),
-                "Victoire des alliés": date(2020, 5, 8),
-                "Vendredi Saint": date(2020, 4, 10),
-                "Saint Étienne": date(2020, 12, 26),
+                "8 mai": date(2020, 5, 8),
+                "Vendredi saint": date(2020, 4, 10),
+                "2ème jour de Noël": date(2020, 12, 26),
             },
         )
 
@@ -127,14 +127,14 @@ class TestDatasetParser(unittest.TestCase):
 
         base = set(
             [
-                "Jour de l'an",
-                "Fête du Travail",
-                "Victoire des alliés",
-                "Fête Nationale",
+                "1er janvier",
+                "1er mai",
+                "8 mai",
+                "14 juillet",
                 "Assomption",
                 "Toussaint",
-                "Armistice",
-                "Noël",
+                "11 novembre",
+                "Jour de Noël",
                 "Lundi de Pâques",
                 "Ascension",
                 "Lundi de Pentecôte",
@@ -142,11 +142,11 @@ class TestDatasetParser(unittest.TestCase):
         )
 
         extra_holidays = [
-            ["Alsace-Moselle", set(["Vendredi Saint", "Saint Étienne"])],
-            ["Guadeloupe", set(["Abolition de l'esclavage"]),],
+            ["Alsace-Moselle", set(["Vendredi saint", "2ème jour de Noël"])],
+            ["Guadeloupe", set(["Abolition de l'esclavage"])],
             ["Guyane", set(["Abolition de l'esclavage"])],
-            ["Martinique", set(["Abolition de l'esclavage"]),],
-            ["Mayotte", set(["Abolition de l'esclavage"]),],
+            ["Martinique", set(["Abolition de l'esclavage"])],
+            ["Mayotte", set(["Abolition de l'esclavage"])],
             ["Nouvelle-Calédonie", set()],
             ["La Réunion", set(["Abolition de l'esclavage"])],
             ["Polynésie Française", set()],

--- a/tests/test.py
+++ b/tests/test.py
@@ -168,7 +168,7 @@ class TestDatasetParser(unittest.TestCase):
             JoursFeries.ZONES, ["Métropole"] + [e[0] for e in extra_holidays]
         )
 
-    def testAbolitionDeLesclavage(self):
+    def testAbolition_esclavage(self):
         tests = [
             ("Mayotte", date(2020, 4, 27)),
             ("Martinique", date(2020, 5, 22)),
@@ -184,16 +184,16 @@ class TestDatasetParser(unittest.TestCase):
             zone, expected_date = test
             zones.add(zone)
             self.assertEquals(
-                JoursFeries.abolitionDeLesclavage(2020, zone), expected_date
+                JoursFeries.abolition_esclavage(2020, zone), expected_date
             )
 
         for zone in [z for z in JoursFeries.ZONES if z not in zones]:
-            self.assertEquals(JoursFeries.abolitionDeLesclavage(2020, zone), None)
+            self.assertEquals(JoursFeries.abolition_esclavage(2020, zone), None)
 
         # Saint-Martin
         self.assertEquals(
-            JoursFeries.abolitionDeLesclavage(2017, "Saint-Martin"), date(2017, 5, 27)
+            JoursFeries.abolition_esclavage(2017, "Saint-Martin"), date(2017, 5, 27)
         )
         self.assertEquals(
-            JoursFeries.abolitionDeLesclavage(2018, "Saint-Martin"), date(2018, 5, 28)
+            JoursFeries.abolition_esclavage(2018, "Saint-Martin"), date(2018, 5, 28)
         )


### PR DESCRIPTION
Dear reviewers,

We've got an important matter to discuss. France is watching us.

See [discussion on data.gouv.fr](https://www.data.gouv.fr/fr/datasets/jours-feries-en-france/#discussion-5eb02e6fc1f140f9b96e6f37). The question was: should we name bank holidays according to the _code du travail_ or should we stick to names used by people?

## Switching to names from _code du travail_
Pros:
- we don't have to pick names
- people have trouble to associate dates and names (When is _Victoire des alliés_ again?)

Cons:
- it's a breaking change
- it's farther away from how people speak

To discuss:
- [x] Rename methods?
- [x] Document name <-> method mapping?